### PR TITLE
fix(node): fix imports

### DIFF
--- a/src/GlyphNode.js
+++ b/src/GlyphNode.js
@@ -5,7 +5,8 @@ import {
 } from 'three/webgpu'
 
 
-import GlyphGeometry from './GlyphGeometry';
+import GlyphNodeGeometry from './GlyphNodeGeometry';
+import GlyphNodeMaterial from './GlyphNodeMaterial';
 
 class Glyph extends Object3D {
 
@@ -18,6 +19,7 @@ class Glyph extends Object3D {
       text,
       font,
       letterSpacing,
+      map,
 
       geometry,
       material,
@@ -28,16 +30,16 @@ class Glyph extends Object3D {
 
     this.addons = addons;
 
-    this.geometry = geometry || new GlyphGeometry({
+    this.geometry = geometry || new GlyphNodeGeometry({
       text,
       font,
       letterSpacing,
       width,
     });
 
-    if (material) {
-      this.material = material;
-    }
+    this.material = material || new GlyphNodeMaterial({
+      map,
+    })
     
     this.mesh = new Mesh(this.geometry, this.material);
 

--- a/src/GlyphNodeGeometry.js
+++ b/src/GlyphNodeGeometry.js
@@ -11,7 +11,7 @@ import { createLayout } from './pure/layout-text'
 import * as vertices from './pure/vertices'
 import { computeBox, computeSphere } from './pure/utils'
 
-export default class GlyphGeometry extends BufferGeometry {
+export default class GlyphNodeGeometry extends BufferGeometry {
   constructor(opt){
     super(opt);
     this._opt = Object.assign({}, opt)

--- a/src/GlyphNodeMaterial.js
+++ b/src/GlyphNodeMaterial.js
@@ -1,4 +1,4 @@
-import { NodeMaterial } from "three";
+import { NodeMaterial } from "three/webgpu";
 
 import {
     vec2,


### PR DESCRIPTION
* `GlyphNode` should import `GlyphNodeGeometry`
* `GlyphNodeMaterial` should import `NodeMaterial` from `three/webgpu`

Also construct a default material if none is provided like we do for the geometry